### PR TITLE
add layout calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ On hovering over a cell:
 
 ❗️ Replace `<your_account>` with your Github username and copy the links to `Pull Request` description:
 
-- [DEMO LINK](https://<your_account>.github.io/layout_calendar/)
-- [TEST REPORT LINK](https://<your_account>.github.io/layout_calendar/report/html_report/)
+- [DEMO LINK](https://self51.github.io/layout_calendar/)
+- [TEST REPORT LINK](https://self51.github.io/layout_calendar/report/html_report/)
 
 ❗️ Copy this `Checklist` to the `Pull Request` description after links, and put `- [x]` before each point after you checked it.
 

--- a/src/index.html
+++ b/src/index.html
@@ -7,13 +7,7 @@
     <link rel="stylesheet" href="./styles/main.scss">
   </head>
   <body>
-    <h1>Calendar</h1>
-
-    <div
-      class="calendar
-      calendar--start-day-sun
-      calendar--month-length-29"
-    >
+    <div class="calendar calendar--start-day-sun calendar--month-length-29">
       <div class="calendar__day"></div>
       <div class="calendar__day"></div>
       <div class="calendar__day"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -8,5 +8,43 @@
   </head>
   <body>
     <h1>Calendar</h1>
+
+    <div
+      class="calendar
+      calendar--start-day-sun
+      calendar--month-length-29"
+    >
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+    </div>
   </body>
 </html>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,3 +1,55 @@
+@import './variables';
+
 body {
   margin: 0;
+  font-family: $calendar-font-family;
+  font-size: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.calendar {
+  display: flex;
+  flex-wrap: wrap;
+  width: $calendar-width;
+  gap: $square-gap-size;
+  padding: 10px;
+
+  @each $day, $day-number in $days {
+    &--start-day-#{$day} &__day:first-child {
+      margin-left: $day-number * $square-size-full;
+    }
+  }
+
+  @for $days-number from 28 through 31 {
+    &--month-length-#{$days-number} &__day:nth-child(n + #{$days-number + 1}) {
+      display: none;
+    }
+  }
+
+  &__day {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: $square-size;
+    width: $square-size;
+    background-color: $square-color;
+    border: $square-border-size solid black;
+    transition-duration: 0.5s;
+
+
+    @for $day from 1 through 31 {
+      &:nth-child(#{$day})::before {
+        content: '#{$day}';
+      }
+    }
+
+    &:hover {
+      cursor: pointer;
+      background-color: #FFBFCB;
+      transform: translateY(-20px);
+      transition-duration: 0.5s;
+    }
+  }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -4,7 +4,7 @@ $square-gap-size: 1px;
 $days-in-row: 7;
 $square-size-full: calc($square-size + $square-gap-size + $square-border-size * 2);
 $square-color: #eee;
-$calendar-font-family: Arial;
+$calendar-font-family: Arial, sans-serif;
 $days: (
   'mon': 0,
   'tue': 1,

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,17 @@
+$square-size: 96px;
+$square-border-size: 1px;
+$square-gap-size: 1px;
+$days-in-row: 7;
+$square-size-full: calc($square-size + $square-gap-size + $square-border-size * 2);
+$square-color: #eee;
+$calendar-font-family: Arial;
+$days: (
+  'mon': 0,
+  'tue': 1,
+  'wed': 2,
+  'thu': 3,
+  'fri': 4,
+  'sat': 5,
+  'sun': 6,
+);
+$calendar-width: calc($square-size-full * $days-in-row);


### PR DESCRIPTION
- [DEMO LINK](https://self51.github.io/layout_calendar/)

- [x] Changing 'month-lengh' and 'start-day' modifier in the code element
reflects in changing calendar layout
- [x] Each day has no modifiers, only class (eg. calendar__day)
- [x] All `Typical Mistakes` from `BEM` lesson theory are checked.
- [x] Code follows all the [Code Style Rules ❗️](https://mate-academy.github.io/layout_task-guideline/html-css-code-style-rules)