### PR TITLE
solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ On hovering over a cell:
 
 ❗️ Replace `<your_account>` with your Github username and copy the links to `Pull Request` description:
 
-- [DEMO LINK](https://<your_account>.github.io/layout_calendar/)
-- [TEST REPORT LINK](https://<your_account>.github.io/layout_calendar/report/html_report/)
+- [DEMO LINK](https://Teslaanazuma.github.io/layout_calendar/)
+- [TEST REPORT LINK](https://Teslaanazuma.github.io/layout_calendar/report/html_report/)
 
 ❗️ Copy this `Checklist` to the `Pull Request` description after links, and put `- [x]` before each point after you checked it.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mate-academy/backstop-config": "latest",
     "@mate-academy/bemlint": "latest",
     "@mate-academy/linthtml-config": "latest",
-    "@mate-academy/scripts": "^1.7.3",
+    "@mate-academy/scripts": "^1.7.9",
     "@mate-academy/stylelint-config": "latest",
     "@parcel/transformer-sass": "^2.12.0",
     "backstopjs": "6.2.2",

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,38 @@
     />
   </head>
   <body>
-    <h1>Calendar</h1>
+    <div class="calendar calendar--start-day-sun calendar--month-length-31">
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+      <div class="calendar__day"></div>
+    </div>
   </body>
 </html>

--- a/src/styles/calendar.scss
+++ b/src/styles/calendar.scss
@@ -1,0 +1,58 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  font-size: $number-font-size;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.calendar {
+  padding: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $gap-size;
+  align-items: center;
+  width: 7 * $cell-size + 6 * $gap-size;
+
+  &__day {
+    box-sizing: border-box;
+    width: $cell-size;
+    height: $cell-size;
+    border: 1px solid $border-color;
+    background-color: $cell-bg-color;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition:
+      background-color $animation-duration,
+      transform $animation-duration;
+
+    &:hover {
+      background-color: #ffbfcb;
+      transform: translateY(-20px);
+    }
+
+    @for $i from 1 through 31 {
+      &:nth-child(#{$i}) {
+        &::before {
+          content: '#{$i}';
+        }
+      }
+    }
+  }
+
+  @each $day, $index in $days {
+    &--start-day-#{$day} :first-child {
+      margin-left: $index * ($cell-size + $gap-size);
+    }
+  }
+
+  @for $length from 28 through 31 {
+    &--month-length-#{$length} :nth-child(n + #{$length + 1}) {
+      display: none;
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,2 @@
-body {
-  margin: 0;
-}
+@import '/src/styles/variables';
+@import '/src/styles/calendar';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,8 @@
+$cell-size: 100px;
+$gap-size: 1px;
+$border-color: #000;
+$cell-bg-color: #eee;
+$number-font-size: 30px;
+$animation-duration: 0.5s;
+$days: ('mon' 0, 'tue' 1, 'wed' 2, 'thu' 3, 'fri' 4, 'sat' 5, 'sun' 6);
+$months: (28, 29, 30, 31);


### PR DESCRIPTION
Display a calendar in the middle of the screen (both horizontally and vertically). Use SCSS and follow BEM. Don't use JS.

Write styles in src/styles/main.scss instead of src/style.css.
Create a markup for the calendar block with 31 days inside
DON'T add numbers in HTML (you will do it using CSS)
Each day is a grey (#eee) 100px square (including 1px black border)
Add a number (Arial 30px) in the center of each day using ::before and [@for](https://sass-lang.com/documentation/at-rules/control/for)
Use flex with 1px gap and limit its width to exactly 7 columns + 10px paddings
Don't use hardcoded px values if they are used several times
Use properly named variables to make all the calculations more clear.
Implement start-day modifier for the calendar with mon, tue, wed, thu, fri, sat and sun values
Use [@each](https://sass-lang.com/documentation/at-rules/control/each) to create all the modifiers
The month should start at the correct column (Monday is the 1st, Friday is the 5th)
You can just add correct margin-left for the first day
Set calendar to start from Sunday by default
Add a modifier month-length for the calendar with values 28, 29, 30 and 31 (use @for)
It sets the last day to show (use [nth-child](https://css-tricks.com/how-nth-child-works/))
Set 31 days by default
On hovering over a cell:

cursor should become pointer
The hovered cell has to become pink (use #FFBFCB)
Move the hovered cell up by 20px (use transform)
All changes should be animated with the duration of 0.5s